### PR TITLE
Crime definitions popup to be closed with a click on the page

### DIFF
--- a/site/js/crimeDefinitions.js
+++ b/site/js/crimeDefinitions.js
@@ -39,4 +39,17 @@ export function showCrimeDefinitions() {
 
     // Append the popup container to the body
     document.body.appendChild(popupContainer); 
+
+    // Function to handle outside click
+    function handleOutsideClick(event) {
+        if (!popupContent.contains(event.target)) {
+            popupContainer.remove();
+            document.removeEventListener('click', handleOutsideClick);
+        }
+    }
+
+    // Add event listener for clicks outside the popup content
+    setTimeout(() => {
+        document.addEventListener('click', handleOutsideClick);
+    }, 0);
 }


### PR DESCRIPTION
Being able to close the crime definitions popup when you click outside of that (anywhere  on the page)